### PR TITLE
Added direct click to download links

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,16 +74,21 @@ All the images are collected from the Internet, and the copyright belongs to the
 <h5>Matlab version</h5>
         
 <ul>
-            <li>The dataset images can be downloaded through their orignal links, which are provided in the mat file. [<a href="https://github.com/MVC-Datasets/MVC/blob/gh-pages/image_links.mat">right click to save the image_links.mat file</a>]</li>
-            <li>The corresponding clothing attribute labels can be found in the excel file, which was formatted as a mat file here. [<a href="https://github.com/MVC-Datasets/MVC/blob/gh-pages/attribute_labels.mat">right click to save the attribute_labels.mat file</a>]</li>
-            <li>The full information of mvc dataset can be found in [<a href="https://github.com/MVC-Datasets/MVC/blob/gh-pages/mvc_info.mat">right click to save the mvc_info.mat file</a>]
-    
+            <li>The dataset images can be downloaded through their orignal links, which are provided in the mat file. 
+              [<a href="https://raw.githubusercontent.com/MVC-Datasets/MVC/gh-pages/image_links.mat">image_links.mat</a>]
+  </li>
+            <li>The corresponding clothing attribute labels can be found in the excel file, which was formatted as a mat file here. 
+              [<a href="https://raw.githubusercontent.com/MVC-Datasets/MVC/gh-pages/attribute_labels.mat">attribute_labels.mat</a>]
+  </li>
+            <li>The full information of mvc dataset can be found in 
+              [<a href="https://raw.githubusercontent.com/MVC-Datasets/MVC/gh-pages/mvc_info.mat">mvc_info.mat</a>]
+  </li>    
 </ul>
         
 <h5>JSON version</h5>
         
 <ul> 
-  <li>[<a href="https://drive.google.com/open?id=0B0oMjGuurWR4ZVZ1X19veUkxeU0">json files</a>] for image_links, attribute_labels, mvc_info.</li>  
+  <li>[<a href="https://drive.google.com/open?id=0B0oMjGuurWR4ZVZ1X19veUkxeU0">json files</a>] for image_links, attribute_labels, mvc_info</li>  
 </ul>
             
 <!--


### PR DESCRIPTION
Added direct click to download in the Matlab dataset download section. This just gave the support to download directly by left click and also downloading from the terminal by copying the link.
Tested to be working at [http://rupesh.info/MVC/](http://rupesh.info/MVC/)